### PR TITLE
Ensure ADT golden tests encoding of new samples.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for hspec-golden-aeson
 
+## 0.6.0.0 -- 2018-01-04
+
+* Test encoding in `roundtripAndGoldenADTSpecs' and 'roundtripAndGoldenADTSpecsWithSettings` functions. This may break current tests because only decoding was tested previously.
+
 ## 0.5.1.0 -- 2018-01-04
 
 * Remove 'Wredundant-constraints' flag.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-golden-aeson
-version: 0.5.1.0
+version: 0.6.0.0
 synopsis: Use tests to monitor changes in Aeson serialization
 description: Use tests to monitor changes in Aeson serialization
 category: Testing

--- a/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
@@ -96,11 +96,12 @@ compareWithGolden topDir mModuleName typeName cap goldenFile = do
   sampleSize <- readSampleSize =<< readFile goldenFile
   newSamples <- mkRandomADTSamplesForConstructor sampleSize (Proxy :: Proxy a) (capConstructor cap) goldenSeed
   whenFails (writeComparisonFile newSamples) $ do
+    goldenBytes <- readFile goldenFile
     goldenSamples :: RandomSamples a <-
-      either (throwIO . ErrorCall) return =<<
-      A.eitherDecode' <$>
-      readFile goldenFile
+      either (throwIO . ErrorCall) return $
+      A.eitherDecode' goldenBytes
     newSamples `shouldBe` goldenSamples
+    encodePretty newSamples `shouldBe` goldenBytes
   where
     whenFails :: forall b c. IO c -> IO b -> IO b
     whenFails = flip onException

--- a/test/Test/Types/BrokenSerialization.hs
+++ b/test/Test/Types/BrokenSerialization.hs
@@ -13,9 +13,9 @@ data Person = Person {
 } deriving (Eq,Show,Generic)
 
 instance ToJSON Person where
-  toJSON (Person name age) = object [
-       "personName" .= name
-    ,  "personAge"  .= age
+  toJSON (Person name' age') = object [
+       "personName" .= name'
+    ,  "personAge"  .= age'
     ]
 instance FromJSON Person where
   parseJSON = withObject "Expected a Person object" $ \o ->

--- a/test/Test/Types/MismatchedToAndFromSerialization.hs
+++ b/test/Test/Types/MismatchedToAndFromSerialization.hs
@@ -14,9 +14,9 @@ data Person = Person {
 
 -- ToJSON and FromJSON use different strings, this should break.
 instance ToJSON Person where
-  toJSON (Person name age) = object [
-       "personName" .= name
-    ,  "personAge"  .= age
+  toJSON (Person name' age') = object [
+       "personName" .= name'
+    ,  "personAge"  .= age'
     ]
 
 instance FromJSON Person where


### PR DESCRIPTION
The ADT golden tests were not testing for encoding changes; they only tested whether the seed generated the same samples and that reading the samples from the golden file matched the newly-generated samples.

This can allow a backward-compatible encoding change to sneak through, which could potentially cause problems for other clients which do not support the new encoding.

For example, hypothetically say `10 :: Int` was originally encoded as `10.0`. But later the encoding changed to `10`. If the `FromJSON` instance can read both `10.0` and `10` as `10 :: Int` then this golden test would never fail even after the encoding changed. However, there was clearly an encoding change, and these tests should flag that change.

We encountered this in real code because `aeson` changed how it encodes `UTCTime` in a similar way, and it could decode both formats.