### PR TITLE
Relax requirement that random generation remain identical.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for hspec-golden-aeson
 
+## 0.7.0.0 -- 2018-05-17
+
+* Breaking change: allow roundtripAndGoldenADTSpecs test to pass when random samples generated from the seed in the golden file do not produce the same Haskell samples, but yet decoding and re-encoding the golden file still produces the same bytes as in the golden file.
+* Add an additional faulty file ending in `.faulty.reencoded.json` when the byte-for-byte decode/encode round-trip fails. This allows you to compare the encoding changes without the noise of the random sample change. In this case, the test will output a message indicating whether decoding the golden file produces the same Haskell values as decoding the re-encoded files. If they produce the same values, that is likely a minor encoding change, but still a change so tests fail.
+* Add `RandomMismatchOption` to `Settings` so you can have the old behavior of failing tests when random samples change.
+
 ## 0.6.0.0 -- 2018-01-04
 
 * Test encoding in `roundtripAndGoldenADTSpecs' and 'roundtripAndGoldenADTSpecsWithSettings` functions. This may break current tests because only decoding was tested previously.

--- a/examples/arbitrary-adt-example/stack.yaml
+++ b/examples/arbitrary-adt-example/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.17
+resolver: lts-11.9
 
 packages:
 - .

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-golden-aeson
-version: 0.6.0.0
+version: 0.7.0.0
 synopsis: Use tests to monitor changes in Aeson serialization
 description: Use tests to monitor changes in Aeson serialization
 category: Testing

--- a/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
@@ -126,9 +126,9 @@ compareWithGolden topDir mModuleName typeName cap goldenFile = do
               failureMessage =
                 if testSamples == goldenSamples
                   then
-                    "Encoding has changed in a minor way; still can read old encodings"
+                    "Encoding has changed in a minor way; still can read old encodings. See " ++ faultyReencodedFile ++ "."
                   else
-                    "Encoding has changed in a major way; cannot read old encodings"
+                    "Encoding has changed in a major way; cannot read old encodings. See " ++ faultyReencodedFile ++ "."
             expectationFailure failureMessage
   where
     whenFails :: forall b c. IO c -> IO b -> IO b

--- a/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
@@ -103,7 +103,7 @@ compareWithGolden topDir mModuleName typeName cap goldenFile = do
     if newSamples == goldenSamples
       then
         -- random samples match; test encoding of samples (the above check only tested the decoding)
-        encodePretty newSamples `shouldBe` goldenBytes
+        encodePretty newSamples == goldenBytes `shouldBe` True
       else do
         -- do a fallback test to determine whether the mismatch is due to a random sample change only,
         -- or due to a change in encoding
@@ -111,7 +111,7 @@ compareWithGolden topDir mModuleName typeName cap goldenFile = do
           "\n" ++
           "WARNING: New random samples do not match those in " ++ goldenFile ++ ".\n" ++
           "  Testing round-trip decoding/encoding of golden file."
-        encodePretty goldenSamples `shouldBe` goldenBytes
+        encodePretty goldenSamples == goldenBytes `shouldBe` True
   where
     whenFails :: forall b c. IO c -> IO b -> IO b
     whenFails = flip onException

--- a/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
@@ -100,8 +100,18 @@ compareWithGolden topDir mModuleName typeName cap goldenFile = do
     goldenSamples :: RandomSamples a <-
       either (throwIO . ErrorCall) return $
       A.eitherDecode' goldenBytes
-    newSamples `shouldBe` goldenSamples
-    encodePretty newSamples `shouldBe` goldenBytes
+    if newSamples == goldenSamples
+      then
+        -- random samples match; test encoding of samples (the above check only tested the decoding)
+        encodePretty newSamples `shouldBe` goldenBytes
+      else do
+        -- do a fallback test to determine whether the mismatch is due to a random sample change only,
+        -- or due to a change in encoding
+        putStrLn $
+          "\n" ++
+          "WARNING: New random samples do not match those in " ++ goldenFile ++ ".\n" ++
+          "  Testing round-trip decoding/encoding of golden file."
+        encodePretty goldenSamples `shouldBe` goldenBytes
   where
     whenFails :: forall b c. IO c -> IO b -> IO b
     whenFails = flip onException

--- a/src/Test/Aeson/Internal/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/GoldenSpecs.hs
@@ -100,7 +100,7 @@ compareWithGolden typeNameInfo proxy goldenFile comparisonFile = do
           "\n" ++
           "WARNING: Encoding new random samples do not match " ++ goldenFile ++ ".\n" ++
           "  Testing round-trip decoding/encoding of golden file."
-        encodePretty goldenSamples `shouldBe` goldenBytes
+        encodePretty goldenSamples == goldenBytes `shouldBe` True
   where
     whenFails :: forall b c . IO c -> IO b -> IO b
     whenFails = flip onException

--- a/src/Test/Aeson/Internal/Utils.hs
+++ b/src/Test/Aeson/Internal/Utils.hs
@@ -25,16 +25,34 @@ import           Prelude
 import           Test.Hspec
 import           Test.QuickCheck
 
-
+-- | Option to indicate whether to create a separate comparison file or overwrite the golden file.
+-- A separate file allows you to use `diff` to compare.
+-- Overwriting allows you to use source control tools for comparison.
 data ComparisonFile
   = FaultyFile
+  -- ^ Create a new faulty file when tests fail
   | OverwriteGoldenFile
+  -- ^ Overwrite the golden file when tests fail
+
+-- | Option indicating whether to fail tests when the random seed does not produce the same values as in the golden file.
+-- Default is to output a warning.
+data RandomMismatchOption
+  = RandomMismatchWarning
+  -- ^ Only output a warning when the random seed does not produce the same values
+  | RandomMismatchError
+  -- ^ Fail the test when the random seed does not produce the same value
 
 data Settings = Settings 
-  { goldenDirectoryOption :: GoldenDirectoryOption -- ^ use a custom directory name or use the generic "golden" directory.
-  , useModuleNameAsSubDirectory :: Bool -- ^ If true, use the module name in the file path, otherwise ignore it.
-  , sampleSize :: Int -- ^ How many instances of each type you want. If you use ADT versions than it will use the sample size for each constructor.
+  { goldenDirectoryOption :: GoldenDirectoryOption
+  -- ^ use a custom directory name or use the generic "golden" directory.
+  , useModuleNameAsSubDirectory :: Bool
+  -- ^ If true, use the module name in the file path, otherwise ignore it.
+  , sampleSize :: Int
+  -- ^ How many instances of each type you want. If you use ADT versions than it will use the sample size for each constructor.
   , comparisonFile :: ComparisonFile
+  -- ^ Whether to create a separate comparison file or ovewrite the golden file.
+  , randomMismatchWarning :: RandomMismatchOption
+  -- ^ Whether to output a warning or fail the test when the random seed produces different values than the values in the golden file.
   }
 
 -- | A custom directory name or a preselected directory name.
@@ -42,7 +60,7 @@ data GoldenDirectoryOption = CustomDirectoryName String | GoldenDirectory
 
 -- | The default settings for general use cases.
 defaultSettings :: Settings
-defaultSettings = Settings GoldenDirectory False 5 FaultyFile
+defaultSettings = Settings GoldenDirectory False 5 FaultyFile RandomMismatchError
 
 -- | put brackets around a String.
 addBrackets :: String -> String

--- a/src/Test/Aeson/Internal/Utils.hs
+++ b/src/Test/Aeson/Internal/Utils.hs
@@ -51,7 +51,7 @@ data Settings = Settings
   -- ^ How many instances of each type you want. If you use ADT versions than it will use the sample size for each constructor.
   , comparisonFile :: ComparisonFile
   -- ^ Whether to create a separate comparison file or ovewrite the golden file.
-  , randomMismatchWarning :: RandomMismatchOption
+  , randomMismatchOption :: RandomMismatchOption
   -- ^ Whether to output a warning or fail the test when the random seed produces different values than the values in the golden file.
   }
 
@@ -60,7 +60,7 @@ data GoldenDirectoryOption = CustomDirectoryName String | GoldenDirectory
 
 -- | The default settings for general use cases.
 defaultSettings :: Settings
-defaultSettings = Settings GoldenDirectory False 5 FaultyFile RandomMismatchError
+defaultSettings = Settings GoldenDirectory False 5 FaultyFile RandomMismatchWarning
 
 -- | put brackets around a String.
 addBrackets :: String -> String

--- a/test/Test/Aeson/GenericSpecsSpec.hs
+++ b/test/Test/Aeson/GenericSpecsSpec.hs
@@ -243,8 +243,7 @@ spec = do
       createDirectoryIfMissing True "golden/Person"
       writeFile "golden/Person/Person.json" goldenByteIdentical
 
-      (s1,results) <- hspecSilently $ goldenADTSpecs defaultSettings (Proxy :: Proxy T.Person)
-      putStrLn results
+      (s1,_) <- hspecSilently $ goldenADTSpecs defaultSettings (Proxy :: Proxy T.Person)
       summaryFailures s1 `shouldBe` 0
 
     it "different random seed but byte-for-byte identical should fail (with custom setting)" $ do
@@ -259,9 +258,8 @@ spec = do
       writeFile "golden/Person/Person.json" goldenByteIdentical
 
       let
-        customSettings = defaultSettings { randomMismatchWarning = RandomMismatchError }
-      (s1,results) <- hspecSilently $ goldenADTSpecs customSettings (Proxy :: Proxy T.Person)
-      putStrLn results
+        customSettings = defaultSettings { randomMismatchOption = RandomMismatchError }
+      (s1,_) <- hspecSilently $ goldenADTSpecs customSettings (Proxy :: Proxy T.Person)
       summaryFailures s1 `shouldBe` 1
 
   describe "mkGoldenFileForType" $ do


### PR DESCRIPTION
# Problem
Occasionally when updating projects and dependencies, especially QuickCheck itself, it can happen that the same `Gen` code will generate a different Haskell value based on the same seed.

This breaks golden tests even though serialization hasn't actually changed. Since the randomly generated Haskell values are different, the faulty golden files are very different. This prevents you from comparing the faulty file for serialization changes. Since this creates false positives, it can also hide a real change if you simply overwrite the golden files with the new ones, thinking that there is only a random generation change, when in fact there may be a real serialization change you didn't miss.

# Solution
Add two fallback tests.

## Fallback Test 1: Allows Tests to Pass
This does a round-trip decode/encode of the golden file. If that produces the same bytes, then the test passes. It means the code still can read the golden file and serialize it byte-for-byte identical.

```
goldenFile == encode (decode goldenFile)
```

## Fallback Test 2: Informative, but tests still fail
If the Fallback Test 1 fails, then there is a serialization change.

The next fallback test indicates how significant of a serialization change has occurred. For Haskell types with an `Eq` instance, it checks decoding the re-encoded file with decoding the original golden file to see if they decode the same Haskell values.

The idea is to check whether reading both serialized forms still gives you the same Haskell values.

Since this is still a serialization change, the tests fail. You must manually change the golden files after verifying the changes are acceptable.

```
decode goldenFile == decode (encode (decode goldenFile))
```

### Examples of minor serialization changes that will pass the fallback
* encoding `1` as `1.0` instead of `1`
* encoding `>` as `\u003e` instead of `>`
* whether there is an endline at the end of the file (or other whitespace changes)