### PR TITLE
Made golden files more portable by truncating seed to 32 bits

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,19 @@
 # Revision history for hspec-golden-aeson
 
+## 0.8.0.0 -- 2021-03-12
+
+* Breaking change: Seed is now an `Int32` so golden files are more portable. This
+  requires regenerating all golden files which have a seed that overflows
+* Breaking change: Golden files are no longer generated automatically if they
+  don't exist, to create them, set the `CREATE_MISSING_GOLDEN` environment variable.
+  This is to prevent missing golden files from silently making golden tests
+  degrade to round-trip tests
+* Add a `RECREATE_MISSING_GOLDEN` environemnt variable. When present it will
+  cause golden files to be re-created if they cause the test to fail. This is
+  useful for updating golden files when serialization has been purposedly
+  modified and to update the seed if it breaks due to overflow now that it is
+  only 32bit wide.
+
 ## 0.7.0.0 -- 2018-05-17
 
 * Breaking change: allow roundtripAndGoldenADTSpecs test to pass when random samples generated from the seed in the golden file do not produce the same Haskell samples, but yet decoding and re-encoding the golden file still produces the same bytes as in the golden file.

--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,7 @@ library:
   - quickcheck-arbitrary-adt >= 0.3.0.0
   - QuickCheck
   - transformers
+  - HUnit
   ghc-options:
   - -Wall
 #  - -Werror

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-golden-aeson
-version: 0.7.0.0
+version: 0.8.0.0
 synopsis: Use tests to monitor changes in Aeson serialization
 description: Use tests to monitor changes in Aeson serialization
 category: Testing

--- a/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
@@ -27,7 +27,7 @@ import           Data.Aeson                (ToJSON, FromJSON)
 import qualified Data.Aeson                as A
 import           Data.Aeson.Encode.Pretty
 import           Data.ByteString.Lazy      (writeFile, readFile)
-import           Data.Int                  (Int32, Int64)
+import           Data.Int                  (Int32)
 import           Data.Proxy
 
 import           Prelude            hiding (writeFile,readFile)
@@ -162,9 +162,7 @@ createGoldenFile :: forall a. (ToJSON a, ToADTArbitrary a) =>
   Int -> ConstructorArbitraryPair a -> FilePath -> IO ()
 createGoldenFile sampleSize cap goldenFile = do
   createDirectoryIfMissing True (takeDirectory goldenFile)
-  -- we generare the seed as Int32 and cast to Int64 so golden files are
-  -- always portable to a 32bit arch without overflow
-  rSeed :: Int64 <- fromIntegral <$> (randomIO :: IO Int32)
+  rSeed <- randomIO :: IO Int32
   rSamples <- mkRandomADTSamplesForConstructor sampleSize (Proxy :: Proxy a) (capConstructor cap) rSeed
   writeFile goldenFile $ encodePretty rSamples
 
@@ -205,7 +203,7 @@ mkFaultyReencodedFilePath topDir mModuleName typeName cap =
 -- | Create a number of arbitrary instances of a particular constructor given
 -- a sample size and a random seed.
 mkRandomADTSamplesForConstructor :: forall a. (ToADTArbitrary a) =>
-  Int -> Proxy a -> String -> Int64 -> IO (RandomSamples a)
+  Int -> Proxy a -> String -> Int32 -> IO (RandomSamples a)
 mkRandomADTSamplesForConstructor sampleSize Proxy conName rSeed = do
   generatedADTs <- generate gen
   let caps         = concat $ adtCAPs <$> generatedADTs
@@ -228,9 +226,7 @@ mkGoldenFileForType sampleSize Proxy goldenPath = do
           then pure ()
           else do
             createDirectoryIfMissing True (takeDirectory goldenFile)
-            -- we generare the seed as Int32 and cast to Int64 so golden files are
-            -- always portable to a 32bit arch without overflow
-            rSeed :: Int64 <- fromIntegral <$> (randomIO :: IO Int32)
+            rSeed <- randomIO :: IO Int32
             rSamples <- mkRandomADTSamplesForConstructor sampleSize (Proxy :: Proxy a) (capConstructor constructor) rSeed
             writeFile goldenFile $ encodePretty rSamples
     ) constructors

--- a/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
@@ -28,11 +28,13 @@ import qualified Data.Aeson                as A
 import           Data.Aeson.Encode.Pretty
 import           Data.ByteString.Lazy      (writeFile, readFile)
 import           Data.Int                  (Int32)
+import           Data.Maybe                (isJust)
 import           Data.Proxy
 
 import           Prelude            hiding (writeFile,readFile)
 
 import           System.Directory
+import           System.Environment        (lookupEnv)
 import           System.FilePath
 import           System.Random
 
@@ -78,7 +80,11 @@ testConstructor Settings{..} moduleName typeName cap = do
     exists <- doesFileExist goldenFile
     if exists
       then compareWithGolden randomMismatchOption topDir mModuleName typeName cap goldenFile
-      else createGoldenFile sampleSize cap goldenFile
+      else do
+        doCreate <- isJust <$> lookupEnv "CREATE_MISSING_GOLDEN"
+        if doCreate
+          then createGoldenFile sampleSize cap goldenFile
+          else expectationFailure $ "Missing golden file: " <> goldenFile
   where
     goldenFile = mkGoldenFilePath topDir mModuleName typeName cap
     topDir = case goldenDirectoryOption of

--- a/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/ADT/GoldenSpecs.hs
@@ -27,7 +27,7 @@ import           Data.Aeson                (ToJSON, FromJSON)
 import qualified Data.Aeson                as A
 import           Data.Aeson.Encode.Pretty
 import           Data.ByteString.Lazy      (writeFile, readFile)
-import           Data.Int                  (Int32)
+import           Data.Int                  (Int32, Int64)
 import           Data.Proxy
 
 import           Prelude            hiding (writeFile,readFile)
@@ -162,7 +162,9 @@ createGoldenFile :: forall a. (ToJSON a, ToADTArbitrary a) =>
   Int -> ConstructorArbitraryPair a -> FilePath -> IO ()
 createGoldenFile sampleSize cap goldenFile = do
   createDirectoryIfMissing True (takeDirectory goldenFile)
-  rSeed <- randomIO :: IO Int32
+  -- we generare the seed as Int32 and cast to Int64 so golden files are
+  -- always portable to a 32bit arch without overflow
+  rSeed :: Int64 <- fromIntegral <$> (randomIO :: IO Int32)
   rSamples <- mkRandomADTSamplesForConstructor sampleSize (Proxy :: Proxy a) (capConstructor cap) rSeed
   writeFile goldenFile $ encodePretty rSamples
 
@@ -203,7 +205,7 @@ mkFaultyReencodedFilePath topDir mModuleName typeName cap =
 -- | Create a number of arbitrary instances of a particular constructor given
 -- a sample size and a random seed.
 mkRandomADTSamplesForConstructor :: forall a. (ToADTArbitrary a) =>
-  Int -> Proxy a -> String -> Int32 -> IO (RandomSamples a)
+  Int -> Proxy a -> String -> Int64 -> IO (RandomSamples a)
 mkRandomADTSamplesForConstructor sampleSize Proxy conName rSeed = do
   generatedADTs <- generate gen
   let caps         = concat $ adtCAPs <$> generatedADTs
@@ -226,7 +228,9 @@ mkGoldenFileForType sampleSize Proxy goldenPath = do
           then pure ()
           else do
             createDirectoryIfMissing True (takeDirectory goldenFile)
-            rSeed <- randomIO :: IO Int32
+            -- we generare the seed as Int32 and cast to Int64 so golden files are
+            -- always portable to a 32bit arch without overflow
+            rSeed :: Int64 <- fromIntegral <$> (randomIO :: IO Int32)
             rSamples <- mkRandomADTSamplesForConstructor sampleSize (Proxy :: Proxy a) (capConstructor constructor) rSeed
             writeFile goldenFile $ encodePretty rSamples
     ) constructors

--- a/src/Test/Aeson/Internal/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/GoldenSpecs.hs
@@ -23,7 +23,7 @@ import           Control.Monad
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import           Data.ByteString.Lazy hiding (putStrLn)
-import           Data.Int (Int32)
+import           Data.Int (Int64)
 import           Data.Proxy
 import           Data.Typeable
 
@@ -171,7 +171,7 @@ mkFaultyReencodedFile (TypeNameInfo {typeNameTypeName,typeNameModuleName, typeNa
 -- | Create a number of arbitrary instances of a type
 -- a sample size and a random seed.
 mkRandomSamples :: forall a . Arbitrary a =>
-  Int -> Proxy a -> Int32 -> IO (RandomSamples a)
+  Int -> Proxy a -> Int64 -> IO (RandomSamples a)
 mkRandomSamples sampleSize Proxy rSeed = RandomSamples rSeed <$> generate gen
   where
     correctedSampleSize = if sampleSize <= 0 then 1 else sampleSize

--- a/src/Test/Aeson/Internal/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/GoldenSpecs.hs
@@ -23,7 +23,7 @@ import           Control.Monad
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import           Data.ByteString.Lazy hiding (putStrLn)
-import           Data.Int (Int64)
+import           Data.Int (Int32)
 import           Data.Proxy
 import           Data.Typeable
 
@@ -171,7 +171,7 @@ mkFaultyReencodedFile (TypeNameInfo {typeNameTypeName,typeNameModuleName, typeNa
 -- | Create a number of arbitrary instances of a type
 -- a sample size and a random seed.
 mkRandomSamples :: forall a . Arbitrary a =>
-  Int -> Proxy a -> Int64 -> IO (RandomSamples a)
+  Int -> Proxy a -> Int32 -> IO (RandomSamples a)
 mkRandomSamples sampleSize Proxy rSeed = RandomSamples rSeed <$> generate gen
   where
     correctedSampleSize = if sampleSize <= 0 then 1 else sampleSize

--- a/src/Test/Aeson/Internal/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/GoldenSpecs.hs
@@ -23,6 +23,7 @@ import           Control.Monad
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import           Data.ByteString.Lazy hiding (putStrLn)
+import           Data.Int (Int32)
 import           Data.Proxy
 import           Data.Typeable
 
@@ -170,9 +171,9 @@ mkFaultyReencodedFile (TypeNameInfo {typeNameTypeName,typeNameModuleName, typeNa
 -- | Create a number of arbitrary instances of a type
 -- a sample size and a random seed.
 mkRandomSamples :: forall a . Arbitrary a =>
-  Int -> Proxy a -> Int -> IO (RandomSamples a)
+  Int -> Proxy a -> Int32 -> IO (RandomSamples a)
 mkRandomSamples sampleSize Proxy rSeed = RandomSamples rSeed <$> generate gen
   where
     correctedSampleSize = if sampleSize <= 0 then 1 else sampleSize
     gen :: Gen [a]
-    gen = setSeed rSeed $ replicateM correctedSampleSize (arbitrary :: Gen a)
+    gen = setSeed (fromIntegral rSeed) $ replicateM correctedSampleSize (arbitrary :: Gen a)

--- a/src/Test/Aeson/Internal/GoldenSpecs.hs
+++ b/src/Test/Aeson/Internal/GoldenSpecs.hs
@@ -24,12 +24,14 @@ import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import           Data.ByteString.Lazy hiding (putStrLn)
 import           Data.Int (Int32)
+import           Data.Maybe (isJust)
 import           Data.Proxy
 import           Data.Typeable
 
 import           Prelude hiding (readFile, writeFile)
 
 import           System.Directory
+import           System.Environment (lookupEnv)
 import           System.FilePath
 import           System.Random
 
@@ -76,7 +78,11 @@ goldenSpecsWithNotePlain settings@Settings{..} typeNameInfo@(TypeNameInfo{typeNa
       exists <- doesFileExist goldenFile
       if exists
         then compareWithGolden typeNameInfo proxy goldenFile comparisonFile
-        else createGoldenfile settings proxy goldenFile
+        else do
+          doCreate <- isJust <$> lookupEnv "CREATE_MISSING_GOLDEN"
+          if doCreate
+            then createGoldenfile settings proxy goldenFile
+            else expectationFailure $ "Missing golden file: " <> goldenFile
 
     
 -- | The golden files already exist. Serialize values with the same seed from

--- a/src/Test/Aeson/Internal/RandomSamples.hs
+++ b/src/Test/Aeson/Internal/RandomSamples.hs
@@ -18,7 +18,7 @@ import           Control.Exception
 
 import           Data.Aeson
 import           Data.ByteString.Lazy (ByteString)
-import           Data.Int (Int64)
+import           Data.Int (Int32)
 
 import           GHC.Generics
 
@@ -32,7 +32,7 @@ import           Test.QuickCheck.Random
 -- try to reproduce the same samples by generating the arbitraries with a seed.
 
 data RandomSamples a = RandomSamples {
-  seed    :: Int64
+  seed    :: Int32
 , samples :: [a]
 } deriving (Eq, Ord, Show, Generic)
 
@@ -44,7 +44,7 @@ setSeed :: Int -> Gen a -> Gen a
 setSeed rSeed (MkGen g) = MkGen $ \ _randomSeed size -> g (mkQCGen rSeed) size
 
 -- | Reads the seed without looking at the samples.
-readSeed :: ByteString -> IO Int64
+readSeed :: ByteString -> IO Int32
 readSeed s = case eitherDecode s :: Either String (RandomSamples Value) of
   Right rSamples -> return $ seed rSamples
   Left err -> throwIO $ ErrorCall err

--- a/src/Test/Aeson/Internal/RandomSamples.hs
+++ b/src/Test/Aeson/Internal/RandomSamples.hs
@@ -11,10 +11,11 @@ Internal module, use at your own risk.
 
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
 
 module Test.Aeson.Internal.RandomSamples where
 
-import           Control.Exception
+import           Test.Aeson.Internal.Utils (aesonDecodeIO)
 
 import           Data.Aeson
 import           Data.ByteString.Lazy (ByteString)
@@ -45,12 +46,8 @@ setSeed rSeed (MkGen g) = MkGen $ \ _randomSeed size -> g (mkQCGen rSeed) size
 
 -- | Reads the seed without looking at the samples.
 readSeed :: ByteString -> IO Int32
-readSeed s = case eitherDecode s :: Either String (RandomSamples Value) of
-  Right rSamples -> return $ seed rSamples
-  Left err -> throwIO $ ErrorCall err
+readSeed = fmap seed . aesonDecodeIO @(RandomSamples Value)
 
 -- | Read the sample size.
 readSampleSize :: ByteString -> IO Int
-readSampleSize s = case eitherDecode s :: Either String (RandomSamples Value) of
-  Right rSamples -> return . length . samples $ rSamples
-  Left err -> throwIO $ ErrorCall err
+readSampleSize = fmap (length . samples) . aesonDecodeIO @(RandomSamples Value)

--- a/src/Test/Aeson/Internal/RandomSamples.hs
+++ b/src/Test/Aeson/Internal/RandomSamples.hs
@@ -18,6 +18,7 @@ import           Control.Exception
 
 import           Data.Aeson
 import           Data.ByteString.Lazy (ByteString)
+import           Data.Int (Int32)
 
 import           GHC.Generics
 
@@ -31,7 +32,7 @@ import           Test.QuickCheck.Random
 -- try to reproduce the same samples by generating the arbitraries with a seed.
 
 data RandomSamples a = RandomSamples {
-  seed    :: Int
+  seed    :: Int32
 , samples :: [a]
 } deriving (Eq, Ord, Show, Generic)
 
@@ -43,7 +44,7 @@ setSeed :: Int -> Gen a -> Gen a
 setSeed rSeed (MkGen g) = MkGen $ \ _randomSeed size -> g (mkQCGen rSeed) size
 
 -- | Reads the seed without looking at the samples.
-readSeed :: ByteString -> IO Int
+readSeed :: ByteString -> IO Int32
 readSeed s = case eitherDecode s :: Either String (RandomSamples Value) of
   Right rSamples -> return $ seed rSamples
   Left err -> throwIO $ ErrorCall err

--- a/src/Test/Aeson/Internal/RandomSamples.hs
+++ b/src/Test/Aeson/Internal/RandomSamples.hs
@@ -18,7 +18,7 @@ import           Control.Exception
 
 import           Data.Aeson
 import           Data.ByteString.Lazy (ByteString)
-import           Data.Int (Int32)
+import           Data.Int (Int64)
 
 import           GHC.Generics
 
@@ -32,7 +32,7 @@ import           Test.QuickCheck.Random
 -- try to reproduce the same samples by generating the arbitraries with a seed.
 
 data RandomSamples a = RandomSamples {
-  seed    :: Int32
+  seed    :: Int64
 , samples :: [a]
 } deriving (Eq, Ord, Show, Generic)
 
@@ -44,7 +44,7 @@ setSeed :: Int -> Gen a -> Gen a
 setSeed rSeed (MkGen g) = MkGen $ \ _randomSeed size -> g (mkQCGen rSeed) size
 
 -- | Reads the seed without looking at the samples.
-readSeed :: ByteString -> IO Int32
+readSeed :: ByteString -> IO Int64
 readSeed s = case eitherDecode s :: Either String (RandomSamples Value) of
   Right rSamples -> return $ seed rSamples
   Left err -> throwIO $ ErrorCall err

--- a/src/Test/Aeson/Internal/Utils.hs
+++ b/src/Test/Aeson/Internal/Utils.hs
@@ -74,8 +74,8 @@ addBrackets s =
 -- roundtrip tests.
 shouldBeIdentity :: (Eq a, Show a, Arbitrary a) =>
   Proxy a -> (a -> IO a) -> Property
-shouldBeIdentity Proxy function =
-  property $ \ (a :: a) -> function a `shouldReturn` a
+shouldBeIdentity Proxy func =
+  property $ \ (a :: a) -> func a `shouldReturn` a
 
 -- | This function will compare one JSON encoding to a subsequent JSON encoding, thus eliminating the need for an Eq instance
 checkAesonEncodingEquality :: forall a . (ToJSON a, FromJSON a) => JsonShow a -> Bool

--- a/src/Test/Aeson/Internal/Utils.hs
+++ b/src/Test/Aeson/Internal/Utils.hs
@@ -89,8 +89,12 @@ checkAesonEncodingEquality (JsonShow a) =
 aesonDecodeIO :: FromJSON a => ByteString -> IO a
 aesonDecodeIO bs = case eitherDecode bs of
   Right a -> return a
-  Left msg -> throwIO $ ErrorCall
-    ("aeson couldn't parse value: " ++ msg)
+  Left msg -> throwIO $ AesonDecodeError msg
+
+data AesonDecodeError = AesonDecodeError String
+  deriving (Show, Eq)
+
+instance Exception AesonDecodeError
 
 -- | Used to eliminate the need for an Eq instance
 newtype JsonShow a = JsonShow a 


### PR DESCRIPTION
Also make tests fail if golden files are missing unless an environment variable is set and added another env var flag to recreaate broken golden files. More details in changelog